### PR TITLE
Building the demo optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.6)
 
 project(LFWATCH)
 
+option(LFWATCH_BUILD_DEMO "Build the demo program" ON)
+
 # Bump up warning levels appropriately for each compiler
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -std=c++11")
@@ -21,5 +23,8 @@ endif()
 
 include_directories(include)
 add_subdirectory(src)
-add_subdirectory(demo)
+
+if (LFWATCH_BUILD_DEMO)
+	add_subdirectory(demo)
+endif()
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ the callback set for the directory with information about the event.
 
 Building
 -
-The library uses CMake to build and compiles to a static linked library. If you want to build the demo
-pass `-DBUILD_DEMO=1` when you run CMake.
+The library uses CMake to build and compiles to a static linked library.
+
+### CMake options
+
+`LFWATCH_BUILD_DEMO` : Build the demo(default ON)
 
 Example
 -


### PR DESCRIPTION
> If you want to build the demo pass -DBUILD_DEMO=1 when you run CMake.

Despite of the above description in README, lfwatch always build the demo project.

This PR introduce `LFWATCH_BUILD_DEMO` cmake option to control building the demo project.